### PR TITLE
fix: node check in chrome browser

### DIFF
--- a/src/internal/plugin/consoleHandlerPlugin/detectedLogStyle.ts
+++ b/src/internal/plugin/consoleHandlerPlugin/detectedLogStyle.ts
@@ -24,6 +24,7 @@ export const detectedLogStyle: LogStyle = (() => {
 
   const isNode =
     typeof process !== 'undefined' &&
+    typeof process.versions !== 'undefined' &&
     typeof process.versions.node !== 'undefined';
 
   return isNonChromiumEdge || isIOsChrome ? 'none' : isNode ? 'ansi' : 'css';


### PR DESCRIPTION
## Summary

When used in chrome browser, the `process.versions` variable doesn't exist.

![chrome_E7lzxLBlet](https://user-images.githubusercontent.com/619650/124124738-18637000-da79-11eb-818a-9a87175cdd82.png)
